### PR TITLE
Fixed exit button on Quiet Hobbies tab to clear parent

### DIFF
--- a/rise-dc-app/src/scheduling_components/pages/QuietHobbiesParticipant.tsx
+++ b/rise-dc-app/src/scheduling_components/pages/QuietHobbiesParticipant.tsx
@@ -36,6 +36,8 @@ export default function QuietHobbiesParticipant({
   const handleCloseModal = () => {
     console.log("Closing modal, current open state:", open);
     setOpen(false);
+    // Properly calls the parent's onClose() which resets everything and removes all overlays.
+    onClose?.();
   };
 
   const handleChooseActivity = (hobbyId: string) => {


### PR DESCRIPTION
Before only set open to false, which closed the QuietHobbyModal and removed its overlay. But it never told the parent EventSelectionModal to close, so  added onClose?.() to call the parent's close function, resets and removes all overlays.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced modal closure behavior to ensure proper synchronization with parent components, improving overall application responsiveness.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->